### PR TITLE
Output the environment we're in when using monk start. Highly crucial to testing and ensuring the config is working.

### DIFF
--- a/Thorfile
+++ b/Thorfile
@@ -30,6 +30,7 @@ class Monk < Thor
   def start(env = ENV["RACK_ENV"] || "development")
     verify_config(env)
     invoke :redis
+    say_status :success, "Starting Monk in #{env} environment"
 
     exec "env RACK_ENV=#{env} ruby init.rb"
   end


### PR DESCRIPTION
We ran into quite a few issues with initial setup and before we'd tuned our .gitignore files for our project where Monk would start on one laptop, then a commit later (from a different person) didn't work. Eventually tracked it down to config files being wrong and changing the environment to production by accident in our code.

This change was highly useful for us, so I think it'll be useful for other people too.
